### PR TITLE
State-dependent Bayesian Interpolation and per-sentence predictor weighting

### DIFF
--- a/cam/sgnmt/decode_utils.py
+++ b/cam/sgnmt/decode_utils.py
@@ -21,7 +21,8 @@ from cam.sgnmt import utils
 from cam.sgnmt.blocks.nmt import blocks_get_nmt_predictor, \
                                  blocks_get_nmt_vanilla_decoder, \
                                  blocks_get_default_nmt_config
-from cam.sgnmt.predictors.parse import ParsePredictor, TokParsePredictor, BpeParsePredictor
+from cam.sgnmt.predictors.parse import ParsePredictor, TokParsePredictor, \
+                                       BpeParsePredictor
 from cam.sgnmt.decoding import combination
 from cam.sgnmt.decoding.astar import AstarDecoder
 from cam.sgnmt.decoding.beam import BeamDecoder
@@ -856,13 +857,19 @@ def do_decode(decoder,
                 logging.info("Next sentence (ID: %d)" % (sen_idx + 1))
             else:
                 src = src_sentences[sen_idx]
-            if len(src) > 0 and ',' in src[-1]:
+            if len(src) > 0 and args.per_sentence_predictor_weights:
                 # change predictor weights per-sentence
                 weights = src[-1].split(',')
-                weights = [float(x) for x in weights]
-                src = src[:-1]
-                logging.info('Changing predictor weights to {}'.format(weights))
-                decoder.change_predictor_weights(weights)
+                if len(weights) > 1:
+                    weights = [float(x) for x in weights]
+                    src = src[:-1]
+                    logging.info('Changing predictor weights to {}'.format(
+                        weights))
+                    decoder.change_predictor_weights(weights)
+                else:
+                    logging.info(
+                        'No weights read in {} - leaving unchanged'.format(
+                            src))
             logging.info("Next sentence (ID: %d): %s" % (sen_idx + 1, ' '.join(src)))
             src = [int(x) for x in src]
             start_hypo_time = time.time()

--- a/cam/sgnmt/decode_utils.py
+++ b/cam/sgnmt/decode_utils.py
@@ -796,6 +796,8 @@ def _postprocess_complete_hypos(hypos):
             breakdown_fn = combination.breakdown2score_bayesian_loglin
         elif args.combination_scheme == 'bayesian':
             breakdown_fn = combination.breakdown2score_bayesian  
+        elif args.combination_scheme == 'bayesian_state_dependent':
+            breakdown_fn = combination.breakdown2score_bayesian_state_dependent  
         else:
             logging.warn("Unknown combination scheme '%s'" 
                          % args.combination_scheme)

--- a/cam/sgnmt/decode_utils.py
+++ b/cam/sgnmt/decode_utils.py
@@ -15,7 +15,6 @@ import time
 import traceback
 import os
 import uuid
-import numpy as np
 
 from cam.sgnmt import ui
 from cam.sgnmt import utils
@@ -797,7 +796,6 @@ def _postprocess_complete_hypos(hypos):
                 hypo.trgt_sentence = hypo.trgt_sentence[:-1]
     if args.nbest > 0:
         hypos = hypos[:args.nbest]
-    domain_task_weights = None
     kwargs={'full': True}
     if args.combination_scheme != 'sum': 
         if args.combination_scheme == 'length_norm':
@@ -859,6 +857,7 @@ def do_decode(decoder,
             else:
                 src = src_sentences[sen_idx]
             if len(src) > 0 and ',' in src[-1]:
+                # change predictor weights per-sentence
                 weights = src[-1].split(',')
                 weights = [float(x) for x in weights]
                 src = src[:-1]

--- a/cam/sgnmt/decoding/combibeam.py
+++ b/cam/sgnmt/decoding/combibeam.py
@@ -5,8 +5,27 @@ each time step.
 from cam.sgnmt import utils
 from cam.sgnmt.decoding.beam import BeamDecoder
 from cam.sgnmt.decoding import combination
+from cam.sgnmt.decoding.core import PartialHypothesis
 import copy
 import logging
+
+
+class CombiStatePartialHypo(PartialHypothesis):
+
+    def __init__(self, initial_states=None):
+        super(CombiStatePartialHypo, self).__init__(initial_states)
+        self.score_minus_last = 0 # score not counting last step
+        self.pred_weights = [] # overall state-dependent predictor weights
+        
+    def _new_partial_hypo(self, states, word, score, score_breakdown):
+        new_hypo = CombiStatePartialHypo(states)
+        new_hypo.score_minus_last = self.score
+        new_hypo.score = self.score + score
+        new_hypo.score_breakdown = copy.copy(self.score_breakdown)
+        new_hypo.trgt_sentence = self.trgt_sentence + [word]
+        new_hypo.pred_weights = copy.copy(self.pred_weights)
+        new_hypo.score_breakdown.append(score_breakdown)
+        return new_hypo
 
 
 class CombiBeamDecoder(BeamDecoder):
@@ -26,26 +45,35 @@ class CombiBeamDecoder(BeamDecoder):
             combination_scheme (string): breakdown2score strategy
         """
         super(CombiBeamDecoder, self).__init__(decoder_args)
+        # Whether to pass combination cached predictor weights
+        self.store_combination_states = True 
         if decoder_args.combination_scheme == 'length_norm':
             self.breakdown2score = combination.breakdown2score_length_norm
         if decoder_args.combination_scheme == 'bayesian_loglin':
             self.breakdown2score = combination.breakdown2score_bayesian_loglin
+        if decoder_args.combination_scheme == 'bayesian_state_dependent':
+            self.breakdown2score = combination.breakdown2score_bayesian_state_dependent
         if decoder_args.combination_scheme == 'bayesian':
             self.breakdown2score = combination.breakdown2score_bayesian
         if decoder_args.combination_scheme == 'sum':
             self.breakdown2score = combination.breakdown2score_sum
         if decoder_args.combination_scheme in ['sum', 'length_norm']:
+            self.store_combination_states = False
             logging.warn("Using the %s combination strategy has no effect "
                          "under the combibeam decoder."
                          % decoder_args.combination_scheme)
         self.maintain_best_scores = False
 
+    def _get_initial_hypos(self):
+        """Get list containing an initial CombiStatePartialHypothesis"""
+        return [CombiStatePartialHypo(self.get_predictor_states())]
+
+
     def _expand_hypo(self, hypo):
         """Get the best beam size expansions of ``hypo``.
         
         Args:
-            hypo (PartialHypothesis): Hypothesis to expans
-        
+            hypo (PartialHypothesis): Hypothesis to expand        
         Returns:
             list. List of child hypotheses
         """
@@ -58,8 +86,16 @@ class CombiBeamDecoder(BeamDecoder):
         expanded_hypos = [hypo.cheap_expand(w, s, score_breakdown[w]) 
                           for w, s in utils.common_iterable(posterior)]
         for expanded_hypo in expanded_hypos:
-            expanded_hypo.score = self.breakdown2score(
-                    expanded_hypo.score, expanded_hypo.score_breakdown)
+            if self.store_combination_states:
+                expanded_hypo.score = self.breakdown2score(
+                    expanded_hypo.score,
+                    expanded_hypo.score_breakdown,
+                    prev_score=expanded_hypo.score_minus_last,
+                    pred_weights=expanded_hypo.pred_weights)
+            else:
+                expanded_hypo.score = self.breakdown2score(
+                    expanded_hypo.score,
+                    expanded_hypo.score_breakdown)
         expanded_hypos.sort(key=lambda x: -x.score)
         return expanded_hypos[:self.beam_size]
 

--- a/cam/sgnmt/decoding/combibeam.py
+++ b/cam/sgnmt/decoding/combibeam.py
@@ -11,7 +11,8 @@ import logging
 import numpy as np
 
 class CombiStatePartialHypo(PartialHypothesis):
-    """Identical to PartialHypothesis, but tracks the last-score-but-one for score combination
+    """Identical to PartialHypothesis, but tracks the 
+    last-score-but-one for score combination
     """
     def __init__(self, initial_states=None):
         super(CombiStatePartialHypo, self).__init__(initial_states)
@@ -68,18 +69,27 @@ class CombiBeamDecoder(BeamDecoder):
         
     @staticmethod
     def get_domain_task_weights(w):
+        """Get array of domain-task weights from string w
+        Returns None if w is None or contains non-square number
+                of weights (currently invalid)
+                or 2D numpy float array of weights otherwise
+        """
         if w is None:
-            logging.critical('Need bayesian_domain_task_weights for state-dependent combination')
+            logging.critical(
+                'Need bayesian_domain_task_weights for state-dependent BI')
         else:
-            domain_weights = map(float, utils.split_comma(w))
+            domain_weights = utils.split_comma(w, float)
             num_domains = int(len(domain_weights) ** 0.5)
             if len(domain_weights) == num_domains ** 2:
-                weights_array = np.reshape(domain_weights, (num_domains, num_domains))
-                logging.info('Using {} for Bayesian Interpolation'.format(weights_array))
+                weights_array = np.reshape(domain_weights,
+                                           (num_domains, num_domains))
+                logging.info('Using {} for Bayesian Interpolation'.format(
+                    weights_array))
                 return weights_array
             else:
-                logging.critical('Require square number of domain-task weights, have {}'.format(
-                    len(domain_weights)))
+                logging.critical(
+                    'Need square number of domain-task weights, have {}'.format(
+                        len(domain_weights)))
 
     def _get_initial_hypos(self):
         """Get list containing an initial CombiStatePartialHypothesis"""

--- a/cam/sgnmt/decoding/combibeam.py
+++ b/cam/sgnmt/decoding/combibeam.py
@@ -8,14 +8,14 @@ from cam.sgnmt.decoding import combination
 from cam.sgnmt.decoding.core import PartialHypothesis
 import copy
 import logging
-
+import numpy as np
 
 class CombiStatePartialHypo(PartialHypothesis):
-
+    """Identical to PartialHypothesis, but tracks the last-score-but-one for score combination
+    """
     def __init__(self, initial_states=None):
         super(CombiStatePartialHypo, self).__init__(initial_states)
         self.score_minus_last = 0 # score not counting last step
-        self.pred_weights = [] # overall state-dependent predictor weights
         
     def _new_partial_hypo(self, states, word, score, score_breakdown):
         new_hypo = CombiStatePartialHypo(states)
@@ -23,7 +23,6 @@ class CombiStatePartialHypo(PartialHypothesis):
         new_hypo.score = self.score + score
         new_hypo.score_breakdown = copy.copy(self.score_breakdown)
         new_hypo.trgt_sentence = self.trgt_sentence + [word]
-        new_hypo.pred_weights = copy.copy(self.pred_weights)
         new_hypo.score_breakdown.append(score_breakdown)
         return new_hypo
 
@@ -46,23 +45,41 @@ class CombiBeamDecoder(BeamDecoder):
         """
         super(CombiBeamDecoder, self).__init__(decoder_args)
         # Whether to pass combination cached predictor weights
-        self.store_combination_states = True 
+        self.breakdown2score_kwargs = {}
         if decoder_args.combination_scheme == 'length_norm':
             self.breakdown2score = combination.breakdown2score_length_norm
         if decoder_args.combination_scheme == 'bayesian_loglin':
             self.breakdown2score = combination.breakdown2score_bayesian_loglin
         if decoder_args.combination_scheme == 'bayesian_state_dependent':
+            self.breakdown2score_kwargs['lambdas'] = self.get_domain_task_weights(
+                decoder_args.bayesian_domain_task_weights)
             self.breakdown2score = combination.breakdown2score_bayesian_state_dependent
         if decoder_args.combination_scheme == 'bayesian':
             self.breakdown2score = combination.breakdown2score_bayesian
         if decoder_args.combination_scheme == 'sum':
             self.breakdown2score = combination.breakdown2score_sum
         if decoder_args.combination_scheme in ['sum', 'length_norm']:
-            self.store_combination_states = False
             logging.warn("Using the %s combination strategy has no effect "
                          "under the combibeam decoder."
                          % decoder_args.combination_scheme)
+        else:
+            self.breakdown2score_kwargs['prev_score'] = None
         self.maintain_best_scores = False
+        
+    @staticmethod
+    def get_domain_task_weights(w):
+        if w is None:
+            logging.critical('Need bayesian_domain_task_weights for state-dependent combination')
+        else:
+            domain_weights = map(float, utils.split_comma(w))
+            num_domains = int(len(domain_weights) ** 0.5)
+            if len(domain_weights) == num_domains ** 2:
+                weights_array = np.reshape(domain_weights, (num_domains, num_domains))
+                logging.info('Using {} for Bayesian Interpolation'.format(weights_array))
+                return weights_array
+            else:
+                logging.critical('Require square number of domain-task weights, have {}'.format(
+                    len(domain_weights)))
 
     def _get_initial_hypos(self):
         """Get list containing an initial CombiStatePartialHypothesis"""
@@ -86,16 +103,12 @@ class CombiBeamDecoder(BeamDecoder):
         expanded_hypos = [hypo.cheap_expand(w, s, score_breakdown[w]) 
                           for w, s in utils.common_iterable(posterior)]
         for expanded_hypo in expanded_hypos:
-            if self.store_combination_states:
-                expanded_hypo.score = self.breakdown2score(
-                    expanded_hypo.score,
-                    expanded_hypo.score_breakdown,
-                    prev_score=expanded_hypo.score_minus_last,
-                    pred_weights=expanded_hypo.pred_weights)
-            else:
-                expanded_hypo.score = self.breakdown2score(
-                    expanded_hypo.score,
-                    expanded_hypo.score_breakdown)
+            if 'prev_score' in self.breakdown2score_kwargs:
+                self.breakdown2score_kwargs['prev_score'] = expanded_hypo.score_minus_last
+            expanded_hypo.score = self.breakdown2score(
+                expanded_hypo.score,
+                expanded_hypo.score_breakdown,
+                **self.breakdown2score_kwargs)
         expanded_hypos.sort(key=lambda x: -x.score)
         return expanded_hypos[:self.beam_size]
 

--- a/cam/sgnmt/decoding/combination.py
+++ b/cam/sgnmt/decoding/combination.py
@@ -139,10 +139,6 @@ def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, ful
     Returns:
         float. Bayesian interpolated predictor scores
     """
-    #lambdas = np.asarray([[1.0, 0.5], [0.0, 0.5]]) # state-independent weights scielo esen
-    #lambdas = np.asarray([[0.9, 0.5, 0.1], [0.1, 0.5, 0.0], [0.0, 0.0, 0.9]]) # single ende
-    #lambdas = np.asarray([[0.3, 0.3, 0.2], [0.4, 0.4, 0.2], [0.3, 0.3, 0.7]]) # continued ende
-
     if not score_breakdown or working_score == utils.NEG_INF:
         return working_score
     if full:
@@ -168,7 +164,7 @@ def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, ful
         alphas = [np.log(w) for (_, w) in score_breakdown[-2]]
         for k, (p_k, _) in enumerate(score_breakdown[-2]):
             alphas[k] += p_k 
-        alpha_prob = np.exp(alphas - utils.log_sum(alphas))
+        alpha_prob = np.exp(alphas - utils.log_sum(alphas)) 
         alpha_prob_lambdas = np.zeros_like(alpha_prob)
         for k in range(len(alpha_prob)):
             for t in range(len(alpha_prob)):
@@ -177,8 +173,6 @@ def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, ful
                   for k, (p, _) in enumerate(score_breakdown[-1])]
         updated_breakdown = [(p, alpha_prob[k])
                              for k, (p, _) in enumerate(score_breakdown[-1])]
-
-
         score_breakdown[-1] = updated_breakdown
         working_score += utils.log_sum(scores)
         return working_score

--- a/cam/sgnmt/decoding/combination.py
+++ b/cam/sgnmt/decoding/combination.py
@@ -190,7 +190,9 @@ def breakdown2score_bayesian_loglin(working_score, score_breakdown, full=False, 
         return working_score
     acc = []
     prev_alphas = [] # list of all alpha_i,k
-    write_priors_to_alphas(score_breakdown, prev_alphas)
+    # Write priors to alphas
+    for (p, w) in score_breakdown[0]:
+        prev_alphas.append(np.log(w)) 
     for pos in score_breakdown: # for each position in the hypothesis
         alphas = []
         sub_acc = []

--- a/cam/sgnmt/decoding/combination.py
+++ b/cam/sgnmt/decoding/combination.py
@@ -55,6 +55,7 @@ def breakdown2score_length_norm(working_score, score_breakdown, full=False):
                         for s in score_breakdown])
     return score / len(score_breakdown)
 
+
 def breakdown2score_bayesian(working_score, score_breakdown, full=False, prev_score=None):
     """This realizes score combination following the Bayesian LM 
     interpolation scheme from (Allauzen and Riley, 2011)
@@ -108,7 +109,10 @@ def breakdown2score_bayesian(working_score, score_breakdown, full=False, prev_sc
         working_score += utils.log_sum(scores)
         return working_score
 
-def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, full=False, prev_score=None, lambdas=None):
+
+def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, 
+                                             full=False, prev_score=None,
+                                             lambdas=None):
     """This realizes score combination following the Bayesian LM 
     interpolation scheme from (Allauzen and Riley, 2011)
     
@@ -144,7 +148,7 @@ def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, ful
     if full:
         acc = []
         alphas = [np.log(w) for (_, w) in score_breakdown[0]]
-        for pos in score_breakdown: # for each position in the hypothesis    
+        for pos in score_breakdown: # for each position in the hypothesis
             for k, (p_k, _) in enumerate(pos):
                 alphas[k] += p_k
             alpha_prob = np.exp(alphas - utils.log_sum(alphas))
@@ -178,9 +182,8 @@ def breakdown2score_bayesian_state_dependent(working_score, score_breakdown, ful
         return working_score
 
 
-
-
-def breakdown2score_bayesian_loglin(working_score, score_breakdown, full=False, prev_score=None):
+def breakdown2score_bayesian_loglin(working_score, score_breakdown, full=False,
+                                    prev_score=None):
     """Like bayesian combination scheme, but uses loglinear model
     combination rather than linear interpolation weights
    

--- a/cam/sgnmt/decoding/core.py
+++ b/cam/sgnmt/decoding/core.py
@@ -378,7 +378,14 @@ class Decoder(Observable):
         """Removes all predictors of this decoder. """
         self.predictors = []
         self.predictor_names = []
-    
+        
+    def change_predictor_weights(self, new_weights):
+        new_preds_and_weights = []
+        for w,  (p, _) in zip(new_weights, self.predictors):
+            new_preds_and_weights.append((p, w))
+        self.predictors = copy.copy(new_preds_and_weights)
+        logging.debug('Changed predictor weights: {}'.format([w for (_, w) in self.predictors]))
+
     def set_heuristic_predictors(self, heuristic_predictors):
         """Define the list of predictors used by heuristics. This needs
         to be called before adding heuristics with ``add_heuristic()``

--- a/cam/sgnmt/decoding/core.py
+++ b/cam/sgnmt/decoding/core.py
@@ -383,8 +383,9 @@ class Decoder(Observable):
         new_preds_and_weights = []
         for w,  (p, _) in zip(new_weights, self.predictors):
             new_preds_and_weights.append((p, w))
-        self.predictors = copy.copy(new_preds_and_weights)
-        logging.debug('Changed predictor weights: {}'.format([w for (_, w) in self.predictors]))
+        self.predictors = new_preds_and_weights
+        logging.debug('Changed predictor weights: {}'.format(
+            [w for (_, w) in self.predictors]))
 
     def set_heuristic_predictors(self, heuristic_predictors):
         """Define the list of predictors used by heuristics. This needs

--- a/cam/sgnmt/predictors/tf_t2t.py
+++ b/cam/sgnmt/predictors/tf_t2t.py
@@ -254,7 +254,7 @@ class T2TPredictor(_BaseTensor2TensorPredictor):
             self._add_problem_hparams(
                 hparams, src_vocab_size, trg_vocab_size, problem_name)
             translate_model = registry.model(model_name)(
-                hparams, tf.estimator.ModeKeys.PREDICT, p_hparams)
+                hparams, tf.estimator.ModeKeys.PREDICT)
             self._inputs_var = tf.placeholder(dtype=tf.int32, shape=[None],
                                               name="sgnmt_inputs")
             self._targets_var = tf.placeholder(dtype=tf.int32, shape=[None], 

--- a/cam/sgnmt/predictors/tf_t2t.py
+++ b/cam/sgnmt/predictors/tf_t2t.py
@@ -84,7 +84,7 @@ def _initialize_t2t(t2t_usr_dir):
 
 def log_prob_from_logits(logits):
     """Softmax function."""
-    return logits - tf.reduce_logsumexp(logits, keep_dims=True)
+    return logits - tf.reduce_logsumexp(logits, keepdims=True)
 
 
 class _BaseTensor2TensorPredictor(Predictor):
@@ -251,7 +251,7 @@ class T2TPredictor(_BaseTensor2TensorPredictor):
                 if hparams.pop_id != self.pop_id:
                   logging.warn("T2T pop_id does not match (%d!=%d)"
                     % (hparams.pop_id, self.pop_id))
-            _, p_hparams = self._add_problem_hparams(
+            self._add_problem_hparams(
                 hparams, src_vocab_size, trg_vocab_size, problem_name)
             translate_model = registry.model(model_name)(
                 hparams, tf.estimator.ModeKeys.PREDICT, p_hparams)
@@ -309,7 +309,7 @@ class T2TPredictor(_BaseTensor2TensorPredictor):
         p_hparams = problem.get_hparams(hparams)
         hparams.problem = problem
         hparams.problem_hparams = p_hparams
-        return hparams, p_hparams
+        return hparams
                 
     def predict_next(self):
         """Call the T2T model in self.mon_sess."""

--- a/cam/sgnmt/predictors/tf_t2t.py
+++ b/cam/sgnmt/predictors/tf_t2t.py
@@ -84,7 +84,7 @@ def _initialize_t2t(t2t_usr_dir):
 
 def log_prob_from_logits(logits):
     """Softmax function."""
-    return logits - tf.reduce_logsumexp(logits, keepdims=True)
+    return logits - tf.reduce_logsumexp(logits, keep_dims=True)
 
 
 class _BaseTensor2TensorPredictor(Predictor):
@@ -255,10 +255,10 @@ class T2TPredictor(_BaseTensor2TensorPredictor):
                 if hparams.pop_id != self.pop_id:
                   logging.warn("T2T pop_id does not match (%d!=%d)"
                     % (hparams.pop_id, self.pop_id))
-            self._add_problem_hparams(
+            _, p_hparams = self._add_problem_hparams(
                 hparams, src_vocab_size, trg_vocab_size, problem_name)
             translate_model = registry.model(model_name)(
-                hparams, tf.estimator.ModeKeys.PREDICT)
+                hparams, tf.estimator.ModeKeys.PREDICT, p_hparams)
             self._inputs_var = tf.placeholder(dtype=tf.int32, shape=[None],
                                               name="sgnmt_inputs")
             self._targets_var = tf.placeholder(dtype=tf.int32, shape=[None], 
@@ -313,7 +313,7 @@ class T2TPredictor(_BaseTensor2TensorPredictor):
         p_hparams = problem.get_hparams(hparams)
         hparams.problem = problem
         hparams.problem_hparams = p_hparams
-        return hparams
+        return hparams, p_hparams
                 
     def predict_next(self):
         """Call the T2T model in self.mon_sess."""

--- a/cam/sgnmt/ui.py
+++ b/cam/sgnmt/ui.py
@@ -686,7 +686,7 @@ def get_parser():
                        "after combination.")
     group.add_argument("--combination_scheme", default="sum",
                         choices=['sum', 'length_norm', 'bayesian', 
-                          'bayesian_loglin'],
+                                 'bayesian_loglin', 'bayesian_state_dependent'],
                         help="This parameter controls how the combined "
                         "hypothesis score is calculated from the predictor "
                         "scores and weights.\n\n"

--- a/cam/sgnmt/ui.py
+++ b/cam/sgnmt/ui.py
@@ -697,8 +697,13 @@ def get_parser():
                         "* 'bayesian': Apply the Bayesian LM interpolation "
                         "scheme from Allauzen and Riley to interpolate the "
                         "predictor scores\n"
+                        "* 'bayesian_state_dependent': Like Bayesian "
+                        "but with state-task weights defined by "
+                        "'bayesian_domain_task_weights' parameter"
                         "* 'bayesian_loglin': Like bayesian, but retain "
                         "loglinear framework.")
+    group.add_argument("--bayesian_domain_task_weights", default=None, 
+                       help="comma-separated string of num_predictors^2 weights, will be reshaped into a num_predictors x num_predictors matrix")
     group.add_argument("--t2t_unk_id", default=-1, type=int,
                         help="unk id for t2t. Used by the t2t predictor")
 

--- a/cam/sgnmt/ui.py
+++ b/cam/sgnmt/ui.py
@@ -637,7 +637,7 @@ def get_parser():
                         "weight for wrapped predictors (e.g. 0.3,0.6) if the "
                         "wrapper is unweighted.")
     group.add_argument("--per_sentence_predictor_weights", default=False,
-                       type=bool, 
+                       type='bool', 
                        help="Assign predictor weights for each sentence. "
                        "Must be set consistent with --predictors as for "
                        "--predictor_weights. Per-sentence weights are set "

--- a/cam/sgnmt/ui.py
+++ b/cam/sgnmt/ui.py
@@ -636,6 +636,20 @@ def get_parser():
                         "assigned the weight 1. You may specify a single "
                         "weight for wrapped predictors (e.g. 0.3,0.6) if the "
                         "wrapper is unweighted.")
+    group.add_argument("--per_sentence_predictor_weights", default=False,
+                       type=bool, 
+                       help="Assign predictor weights for each sentence. "
+                       "Must be set consistent with --predictors as for "
+                       "--predictor_weights. Per-sentence weights are set "
+                       "by appending a comma-separated string of weights "
+                       "to the end of source sentences. e.g. 'X1 X2 X3' "
+                       "with two predictors might become "
+                       "'X1 X2 X3 pred1_w,pred2_w' "
+                       "a sentence with no weight str means each predictor is "
+                       "assigned the weights set in --predictor_weights "
+                       " or 1 if --predictor_weights is not set ")
+
+
     group.add_argument("--interpolation_strategy", default="",
                         help="This parameter specifies how the predictor "
                         "weights are used.\n"
@@ -697,12 +711,16 @@ def get_parser():
                         "scheme from Allauzen and Riley to interpolate the "
                         "predictor scores\n"
                         "* 'bayesian_state_dependent': Like Bayesian "
-                        "but with state-task weights defined by "
+                        "but with model-task weights defined by "
                         "'bayesian_domain_task_weights' parameter"
                         "* 'bayesian_loglin': Like bayesian, but retain "
                         "loglinear framework.")
     group.add_argument("--bayesian_domain_task_weights", default=None, 
-                       help="comma-separated string of num_predictors^2 weights, will be reshaped into a num_predictors x num_predictors matrix")
+                       help="comma-separated string of num_predictors^2 "
+                       "weights where rows are domains and "
+                       "tasks are columns, e.g. w[k, t] gives weight on domain k "
+                       "for task t. will be reshaped into "
+                       "a num_predictors x num_predictors matrix")
     group.add_argument("--t2t_unk_id", default=-1, type=int,
                         help="unk id for t2t. Used by the t2t predictor")
 


### PR DESCRIPTION
- New combination scheme in decoding/combination.py: bayesian_state_dependent, which uses new parameter bayesian_domain_task_weights
- Make PartialHypothesis an object: allows subclassing in decoding/combibeam for a PartialHypo that tracks the last-score-but-one for slightly more efficient bayesian interpolation. (These objects could probably be combined.)
- Ability to change predictor weights per-sentence. In decode_utils, if a src line is of form ID1 ID2 ... IDN w1,w2,...,wp where p is the number of predictors, set the predictor weights to w1... wp